### PR TITLE
Add me as attendee

### DIFF
--- a/backstage-community-sessions/README.md
+++ b/backstage-community-sessions/README.md
@@ -13,7 +13,7 @@ Monthly meetup organized by Backstage core team with contributors.
 
 Attendees -
 
-- Jacob Valdemar, @JacobValdemar, [Lunar](https://github.com/lunarway)
+- Jacob Valdemar, @JacobValdemar, Lunar (@lunarway)
 - Name, @GitHubUserName, Company
 - Name, @GitHubUserName, Company
 

--- a/backstage-community-sessions/README.md
+++ b/backstage-community-sessions/README.md
@@ -13,6 +13,7 @@ Monthly meetup organized by Backstage core team with contributors.
 
 Attendees -
 
+- Jacob Valdemar, @JacobValdemar, [Lunar](https://github.com/lunarway)
 - Name, @GitHubUserName, Company
 - Name, @GitHubUserName, Company
 


### PR DESCRIPTION
IDK if Lunar should be a link to our GH org or our main page lunar.app or it should be our @lunarway gh handle.

We can use this PR to set the standard for how details should be inserted 🙂