### PR TITLE
Adds Open Mic to meetups section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,17 @@ For support or more immediate technical discussions, join us in [Discord](https:
 
 ## Meetups
 
-Backstage Community Sessions, hosted by Spotify
+**Backstage Community Sessions, hosted by Spotify**
 
 ![Poster](/backstage-community-sessions/assets/Backstage%20Community%20Sessions.png)
 
 - Join monthly meetups organized by the Backstage core team and contributors
 - [View upcoming agendas, notes, and archives](backstage-community-sessions)
 - [View Google calendar](https://calendar.google.com/calendar/embed?src=c_qup9gbhn9sqpuao6trttd8mk5s@group.calendar.google.com) (Click + to add)
+
+**Backstage Open Mic**
+
+[Open Mic](https://backstage-openmic.com/) is a monthly get-together of users sharing their experiences working with Backstage in their teams and insights about the ecosystem's plugins. 
 
 ## Newsletters
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For support or more immediate technical discussions, join us in [Discord](https:
 - [View upcoming agendas, notes, and archives](backstage-community-sessions)
 - [View Google calendar](https://calendar.google.com/calendar/embed?src=c_qup9gbhn9sqpuao6trttd8mk5s@group.calendar.google.com) (Click + to add)
 
-**Backstage Open Mic**
+**Backstage Open Mic, hosted by Frontside**
 
 [Open Mic](https://backstage-openmic.com/) is a monthly get-together of users sharing their experiences working with Backstage in their teams and insights about the ecosystem's plugins. 
 


### PR DESCRIPTION
## Motivation 

Open Mic is an event organized by Backstage users, we'll be hosting our first even at the end of the month. @OrkoHunter suggested we could add the event to this list of resources.

## Approach

The other categories in the README use lists to reference different resources. However, "Meetups" used the list to showcase links about "Backstage Community Sessions." I took the route of making what existed into a kind of title, and adding Open Mic at the same level.

I did not replicate the structure of Backstage Community Sessions for Open Mic, and instead opted for a brief paragraph.