### PR TITLE
Added a backlog of links to posts, podcasts, talks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the [Backstage](https://github.com/backstage/backstage) community!
 
-Here you will find ways to engage with the community — join meetups, sign up for newsletters, catch up on podcasts, talks, and so many other things happening around Backstage. 
+Here you will find ways to engage with the community — join meetups, sign up for newsletters, catch up on podcasts, talks, and so many other things happening around Backstage.
 
 For support or more immediate technical discussions, join us in [Discord](https://discord.gg/MUpMjP2).
 
@@ -18,7 +18,7 @@ For support or more immediate technical discussions, join us in [Discord](https:
 
 **Backstage Open Mic, hosted by Frontside**
 
-[Open Mic](https://backstage-openmic.com/) is a monthly get-together of users sharing their experiences working with Backstage in their teams and insights about the ecosystem's plugins. 
+[Open Mic](https://backstage-openmic.com/) is a monthly get-together of users sharing their experiences working with Backstage in their teams and insights about the ecosystem's plugins.
 
 ## Newsletters
 
@@ -27,16 +27,20 @@ For support or more immediate technical discussions, join us in [Discord](https:
 
 ## Podcasts
 
-- [The Kubelist Podcast, Episode #11: Backstage with Lee Mills and Matt Clarke of Spotify](https://www.heavybit.com/library/podcasts/the-kubelist-podcast/ep-11-backstage-with-lee-mills-and-matt-clarke-of-spotify/)
-- [Kubernetes Podcast from Google, Episode 136: Backstage Kubernetes](https://kubernetespodcast.com/episode/136-backstage/)
+- [ThoughtWorks: "Making developer effectiveness a reality"](https://www.thoughtworks.com/podcasts/developer-effectiveness)
+- [Spotify: A Product Story, Episode 08: “When to build vs buy — and when to open source”](https://open.spotify.com/episode/7iuQ3ew1Wwpuiq6LbBKzCl)
+- [The Kubelist Podcast, Episode #11: "Backstage with Lee Mills and Matt Clarke of Spotify"](https://www.heavybit.com/library/podcasts/the-kubelist-podcast/ep-11-backstage-with-lee-mills-and-matt-clarke-of-spotify/)
+- [Kubernetes Podcast from Google, Episode 136: "Backstage Kubernetes"](https://kubernetespodcast.com/episode/136-backstage/)
 - [Software Engineering Daily: "Backstage: Spotify Developer Portals"](https://softwareengineeringdaily.com/2020/11/19/backstage-spotify-developer-portals-with-stefan-alund/)
 - [Technology Radar, Vol. 23](https://www.youtube.com/watch?v=CUTSnAutoAM&t=1176)
 - [Changelog, Episode 415: "Spotify's open platform for shipping at scale"](https://changelog.com/podcast/415)
 
 ## Talks
 
+- [Productivity Engineering Silicon Valley: "Developer Portals and Platforms" Panel Discussion with Spotify, Lyft, PayPal, and Netflix](https://www.youtube.com/watch?v=ajN9-dWSVYs)
+- [KubeCon + CloudNativeCon Europe 2021](https://kccnceu2021.sched.com/event/iE4G/techdocs-unlocking-the-potential-of-engineers-collective-knowledge-emma-indal-spotify): ["TechDocs: Unlocking the Potential of Engineers' Collective Knowledge"](https://youtu.be/aIURaocR5D8) (video)
 - [Reddit AMA on r/kubernetes](https://www.reddit.com/r/kubernetes/comments/lwb31v/were_the_engineers_rethinking_kubernetes_at/)
-- [All Things Open 2020](https://www.youtube.com/watch?v=3FR0G0XRDMA)
+- [All Things Open 2020: "Backstage.io: Spotify's platform developer experience"](https://www.youtube.com/watch?v=3FR0G0XRDMA)
 
 ## Case Studies
 
@@ -44,13 +48,16 @@ For support or more immediate technical discussions, join us in [Discord](https:
 
 ## Blogs
 
+- [A Product Story: The Lessons of Backstage and Spotify’s Autonomous Culture - Spotify Engineering](https://engineering.atspotify.com/2021/05/18/a-product-story-the-lessons-of-backstage-and-spotifys-autonomous-culture/)
 - [Shifting cost optimisation left: Spotify Backstage Cost Insights - RedMonk](https://redmonk.com/jgovernor/2021/04/28/shifting-cost-optimisation-left-spotify-backstage-cost-insights/)
   - [A RedMonk Conversation: Shifting cost optimisation left: Spotify Backstage Cost Insights](https://redmonk.com/videos/a-redmonk-conversation-shifting-cost-optimisation-left-spotify-backstage-cost-insights/) (video)
   - [What is cloud cost optimization? How to manage cloud costs with Spotify Backstage](https://redmonk.com/videos/what-is-cloud-cost-optimization-how-to-manage-cloud-costs-with-spotify-backstage/) (video)
 - [Technology Radar, Vol. 24: Platforms](https://assets.thoughtworks.com/assets/technology-radar-vol-24-en.pdf), [Backstage blip - ThoughtWorks](https://www.thoughtworks.com/radar/platforms?blipid=202010066)
 - [Optimizing micro-feedback loops in engineering - LeadDev](https://leaddev.com/productivity-eng-velocity/optimizing-micro-feedback-loops-engineering)
 - [Backstage integration with the Snyk API - Snyk Blog](https://snyk.io/blog/backstage-integration-with-the-snyk-api/)
+- [Happy Birthday, Backstage: Spotify’s Biggest Open Source Project Grows Up Fast - Spotify Engineering](https://engineering.atspotify.com/2021/03/16/happy-birthday-backstage-spotifys-biggest-open-source-project-grows-up-fast/)
 - [How Spotify Leverages Paved Paths and Common Tooling to Improve Productivity - InfoQ](https://www.infoq.com/news/2021/03/spotify-paved-paths/)
+- [Designing a Better Kubernetes Experience for Developers - Spotify Engineering](https://engineering.atspotify.com/2021/03/01/designing-a-better-kubernetes-experience-for-developers/)
 - [Design a Better Kubernetes Experience for Developers - The New Stack](https://thenewstack.io/design-a-better-kubernetes-experience-for-developers/)
 - [Maximizing Developer Effectiveness - martinfowler.com](https://martinfowler.com/articles/developer-effectiveness.html)
 - [Showcase - Material-UI](https://material-ui.com/discover-more/showcase/)


### PR DESCRIPTION
Various links from the last 3 months, including ThoughtWorks podcast, KubeCon talk, Prod Eng Silicon Valley panel discussion, Spotify Engineering blog posts, etc. (Some formatting tweaks, too.)

Signed-off-by: Jeff Feng <fengypants@gmail.com>