### PR TITLE
RFC: Introducing SIGs into the Backstage community

### DIFF
--- a/sigs/README.md
+++ b/sigs/README.md
@@ -22,4 +22,4 @@ We are currently in the process of introducing SIGs (May 2022) and want to start
 
 ### Can I start a new SIG?
 
-SIGs come with a fair bit of overhead and we would like to be very deliberate when introducing new SIGs as the concept is new and we’re actively iterating. It’s probably a better idea to request a specific channel on discord but feel free to reach out to a maintainer if you have more questions.
+SIGs come with a fair bit of overhead and we would like to be very deliberate when introducing new SIGs as the concept is new and we’re actively iterating. It’s probably a better idea to request a specific channel on Discord but feel free to reach out to a maintainer if you have more questions.

--- a/sigs/README.md
+++ b/sigs/README.md
@@ -1,0 +1,25 @@
+# SIG
+
+SIG is a shorthand for Special Interest Group – a collection of people with special interest in a certain area of Backstage.
+
+Active SIGs
+
+- [sig-catalog](./sig-catalog/README.md)
+
+## FAQ
+
+### How do I join a SIG?
+
+Show up to the meetings! Other than the leadership, SIGs do not have a fixed membership list. Anyone with an interest can show up and join in on discussions. You can find the list of meetings in the README of each SIG.
+
+### How can I get more insight into a SIG without joining?
+
+Each SIG has a document where notes are added from the recurring meetings, this can provide insight into what is currently being discussed in the SIG. You will find this document in the SIG README. There’s also a Discord channel for each SIG.
+
+### Why isn’t there a SIG for X?
+
+We are currently in the process of introducing SIGs (May 2022) and want to start things off a bit carefully. Once initial SIGs have been spun up and there is a good pattern to replicate, there will likely be many more SIGs added to the list.
+
+### Can I start a new SIG?
+
+SIGs come with a fair bit of overhead and we would like to be very deliberate when introducing new SIGs as the concept is new and we’re actively iterating. It’s probably a better idea to request a specific channel on discord but feel free to reach out to a maintainer if you have more questions.

--- a/sigs/sig-catalog/README.md
+++ b/sigs/sig-catalog/README.md
@@ -1,0 +1,60 @@
+# SIG Catalog
+
+SIG Catalog covers all aspects of the systems and components related to the Software Catalog. This includes its backend service and corresponding frontend, including their APIs and extension points, as well as the System Entity Model.
+
+## Meetings
+
+SIG Catalog(biweekly), 16.00 Europe/Stockholm time [Convert to your time zone](https://dateful.com/convert/stockholm-sweden?t=16)
+
+- [Meeting Link](#TODO)
+- [Meeting Notes](#TODO) - Suggest topics for the next meeting here
+- Agenda:
+  - Triage catalog-tagged open issues and pull requests active since the last meeting
+  - Highlight significant changes or pull requests
+  - Cover discussion points raised in the meeting notes doc. 5 minutes per topic with a quick vote for continued discussion
+  - Open floor if there is time to spare
+
+See [Google Calendar](#TODO) for upcoming meetings.
+
+## Contact
+
+Discord: #sig-catalog
+
+GitHub Team: @backstage/sig-catalog
+
+## Leadership
+
+The SIG Catalog team is composed of
+
+### Organizers
+
+The organizers of the SIG run operations and processes governing the SIG.
+
+- Fredrik Adelöw ([@freben](https://github.com/freben))
+- Francesco Corti ([@fcorti](https://github.com/fcorti))
+
+### Tech Leads
+
+The Tech Leads of the SIG manage technical direction and have formal code ownership of subprojects that fall within the scope of this SIG. This includes for example establishing or decommissioning subprojects, resolving technical issues and decisions etc.
+
+- [@backstage/maintainers](https://github.com/backstage/backstage/blob/master/OWNERS.md#maintainers)
+
+Other roles will be introduced once the SIG is established.
+
+## Scope
+
+The following packages fall under the scope of SIG Catalog
+
+- @backstage/catalog-model
+- @backstage/catalog-client
+- @backstage/plugin-catalog
+- @backstage/plugin-catalog-react
+- @backstage/plugin-catalog-common
+- @backstage/plugin-catalog-backend
+- @backstage/plugin-catalog-backend-module-*
+- @backstage/plugin-catalog-import
+
+The following documentation falls under the scope of SIG Catalog
+
+- docs/features/software-catalog
+- Other documentation pages directly related to the functionality of the above packages


### PR DESCRIPTION
Backstage and our fantastic community is growing larger every day and so does the desire to engage with fellow community members and find ways to contribute to the project. The Adopters and Contributors community sessions have helped a lot in this area but we want to have more focused conversations and introduce more ways for community members to get involved and contribute to Backstage.

That’s why we believe that it’s time to introduce Special Interest Groups (SIGs). The concept is nothing new and you might be familiar with them from the Kubernetes project which is largely organized around SIGs.

The idea behind a SIG is to gather community members with a special interest in a particular area of Backstage. The group will meet occasionally and discuss topics that fall under the scope of that specific group. That also involves bug tracking, feature requests, RFCs and pull requests.

We want to kickstart SIGs with the introduction of `sig-catalog`. The catalog is fundamental to Backstage; we believe that it has enough traction and community engagement to warrant a dedicated SIG.

It’s a deliberate choice to start with a few select groups in order to learn and establish good patterns that we can mirror in potential future SIGs. 

The specific date for the first sig-catalog meeting will be announced in advance on Discord and the sig-catalog readme will be updated accordingly.

More information can be found in the catalog-sig readme alongside the general SIG readme. Feel free to raise questions or concerns and we’ll make sure to update this PR accordingly.

/Backstage maintainer team
