### PR TITLE
Updated newsletter sign-up link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Checkout [backstage.io/on-demand](https://backstage.io/on-demand) for the latest
 
 ## Newsletters
 
-- [Official newsletter by Spotify](https://mailchi.mp/spotify/backstage-community)
+- [Official newsletter by Spotify](https://info.backstage.spotify.com/newsletter_subscribe)
 - [Backstage Weekly by Roadie.io](https://roadie.io/backstage-weekly/)
 
 ## Podcasts


### PR DESCRIPTION
The Backstage newsletter from Spotify has migrated to a new distribution platform. So if you haven't signed up for it yet, here's a brand new, shiny link to get on the list.