### PR TITLE
Add new project areas section

### DIFF
--- a/project-areas/Maintainer-Guidance.md
+++ b/project-areas/Maintainer-Guidance.md
@@ -110,32 +110,81 @@ pre-releases before reaching stable.
 
 ## Tools
 
-### Issue Triage
+This section describes a few tools and strategies that can be used to
+collaborate and manage work within each project area.
 
-### Triage Strategies
+### Issue Triage Strategies
+
+This section lists different ways in which you can triage issues within your
+project area. Issue triage is an important process to make sure that issues are
+responded to in a timely manner, and that the right people are involved in the
+discussion.
 
 #### Regularly Scheduled Sync
 
-meet every X, open issues, PR that need discussion
+Use a regularly scheduled meeting to cycle through all issues that have had
+updates since the last meeting. This is the approached used by the core
+maintainers, and they use the
+[`github-sync-helper`](https://github.com/benjdlambert/github-sync-helper) tool
+to automatically open all issues that have been updated. To open all issues that
+have been changed in the last 7 days in the catalog area, you can use the
+following command:
 
-filter by label
+```bash
+npx github-sync-helper issues --days 7 --labels area:catalog
+```
+
+When executing this command each issue will be opened in your default browser.
+Typically one person executed this command, shares their screen, and drives the
+meeting. While working through the issues to gether you typically use a
+combination of the following to respond to issues:
+
+- The driver takes some quick notes and writes the full response after the
+  meeting.
+- An issue is assigned to an individual that will respond to it.
+- Short responses can be written directly together in the meeting.
 
 #### Rotating "Goalie"
 
+A rotating "goalie" role is set up, where the goalie triages, responds, or
+assigns issues. Typically you would rotate goalie every week, but other
+schedules can of course be set up too. The benefit of a rotating goalie is that
+is provides a clearer owner of the triage process, it brings everyone into the
+work, and it lets the rest of the team focused on other work. Drawbacks of a
+goalie rotation is that it can be daunting work, and it doesn't encourage as
+much collaboration in the triage process.
+
 ### Pull Request Strategies
+
+This section lists different ways in which you can manage Pull Request reviews
+within your project area.
 
 #### Randomized Pull Request Assignment
 
-GitHub team settings ->
+GitHub has a feature that allows you to randomly assign an individual reviewer
+to each pull request. It can be found on the team settings page:
+`https://github.com/orgs/backstage/teams/<name>/edit/review_assignment`. With
+this in place each pull request where the team would be marked for review, an
+individual member of the team will be asked to review instead. There are several
+different strategies for how reviews are divided that you can use. It also takes
+into consideration if members set their GitHub status to "Busy", in which case
+they will not receive any new reviews.
 
-#### Assignment during
+#### Assignment During Issue Triage
+
+One strategy for handling pull requests is to triage them together with your
+issue process. For example, of you use sync meeting you might assign new pull
+requests during that meeting, or in case of a goalie, the goalie might review
+and/or assign pull requests to other maintainers. The benefits and drawbacks of
+using the goalie approach are similar to the ones mentioned in the issue triage
+section.
 
 ### Pull request pair/mob review
 
-Tricky PRs, one or more maintainers
-
-### Review Each Others' Pull Requests
-
-### Discord text channel
-
-### Discord voice channel
+A separate strategy that can be used to review pull requests are pair or mob
+reviews. Typically this takes the form of a scheduled or ad-hoc meeting where
+you walk through the pull request together. If the pull request is authored by
+one of the team member they would typically explain it to the rest of the group,
+or if it is an external pull request anyone can drive the walkthrough. This is
+particularly useful for complicated pull requests and can in many cases end up
+being a time saver compared to reviewing the pull request asynchronously.

--- a/project-areas/Maintainer-Guidance.md
+++ b/project-areas/Maintainer-Guidance.md
@@ -1,6 +1,6 @@
 # Project Area Ways of Working
 
-This document the ways of working that are common across all project areas, as
+This documents the ways of working that are common across all project areas, as
 well additional practices that may be adopted by individual areas.
 
 ## Common
@@ -23,14 +23,14 @@ responded to by the maintainers of the relevant project area. In particular we
 have stale bot in place to prune inactive issues, and it doesn't look good if
 issues are marked as stale without a response.
 
-Our stale bot is in place both to close old issue, but also to keep bringing up
+Our stale bot is in place to close old issues, as well as to keep bringing up
 existing issues to the forefront so that all issues throughout the project are
 considered at a regular cadence. If there is an issue that you want to leave
 open without having it marked as stale, you can add the `will-fix` label.
 
 ### Pull Request Management
 
-The division of pull request among project areas is based on the GitHub reviewer
+The division of pull requests among project areas is based on the GitHub reviewer
 feature, rather than labels or assignment. This is because it automatically
 works with the code owners feature, and also makes it possible for each team to
 decide if they want individual assignment of pull requests through the GitHub
@@ -54,7 +54,7 @@ if you are leaving a review where you would not like the pull request to be
 merged as is. This is both to clarify to the author that the pull request is not
 ready to be merged, but also to update the status of the pull request in the
 pull request review board, more on that below. If you simply want to contribute
-to a discussion in the pull requests you can leave a regular comment.
+to the discussion in a pull request you can just leave a regular comment.
 
 Even though a pull request may only change code owned by a single project area,
 it may indirectly affect other project areas or the project as a whole. If this
@@ -123,7 +123,7 @@ discussion.
 #### Regularly Scheduled Sync
 
 Use a regularly scheduled meeting to cycle through all issues that have had
-updates since the last meeting. This is the approached used by the core
+updates since the last meeting. This is the approach used by the core
 maintainers, and they use the
 [`github-sync-helper`](https://github.com/benjdlambert/github-sync-helper) tool
 to automatically open all issues that have been updated. To open all issues that
@@ -135,8 +135,8 @@ npx github-sync-helper issues --days 7 --labels area:catalog
 ```
 
 When executing this command each issue will be opened in your default browser.
-Typically one person executed this command, shares their screen, and drives the
-meeting. While working through the issues to gether you typically use a
+Typically one person executes this command, shares their screen, and drives the
+meeting. While working through the issues together you typically use a
 combination of the following to respond to issues:
 
 - The driver takes some quick notes and writes the full response after the
@@ -181,10 +181,10 @@ section.
 
 ### Pull request pair/mob review
 
-A separate strategy that can be used to review pull requests are pair or mob
+A separate strategy that can be used to review pull requests is pair or mob
 reviews. Typically this takes the form of a scheduled or ad-hoc meeting where
 you walk through the pull request together. If the pull request is authored by
-one of the team member they would typically explain it to the rest of the group,
+one of the team members they would typically explain it to the rest of the group,
 or if it is an external pull request anyone can drive the walkthrough. This is
 particularly useful for complicated pull requests and can in many cases end up
 being a time saver compared to reviewing the pull request asynchronously.

--- a/project-areas/Maintainer-Guidance.md
+++ b/project-areas/Maintainer-Guidance.md
@@ -154,7 +154,7 @@ work, and it lets the rest of the team focused on other work. Drawbacks of a
 goalie rotation is that it can be daunting work, and it doesn't encourage as
 much collaboration in the triage process.
 
-### Pull Request Strategies
+### Pull Request Review Strategies
 
 This section lists different ways in which you can manage Pull Request reviews
 within your project area.

--- a/project-areas/Maintainer-Guidance.md
+++ b/project-areas/Maintainer-Guidance.md
@@ -1,7 +1,7 @@
 # Project Area Ways of Working
 
 This documents the ways of working that are common across all project areas, as
-well additional practices that may be adopted by individual areas.
+well as additional practices that may be adopted by individual areas.
 
 ## Common
 
@@ -151,7 +151,7 @@ assigns issues. Typically you would rotate goalie every week, but other
 schedules can of course be set up too. The benefit of a rotating goalie is that
 is provides a clearer owner of the triage process, it brings everyone into the
 work, and it lets the rest of the team focused on other work. Drawbacks of a
-goalie rotation is that it can be daunting work, and it doesn't encourage as
+goalie rotation are that it can be daunting work, and it doesn't encourage as
 much collaboration in the triage process.
 
 ### Pull Request Review Strategies

--- a/project-areas/Maintainer-Guidance.md
+++ b/project-areas/Maintainer-Guidance.md
@@ -1,0 +1,141 @@
+# Project Area Ways of Working
+
+This document the ways of working that are common across all project areas, as
+well additional practices that may be adopted by individual areas.
+
+## Common
+
+### Issue Management
+
+Issues are triaged and sorted into the appropriate project areas through
+automation as well as curation by the core maintainers. Each project area has an
+associated GitHub label of the format `area:<name>`. These labels are used to
+signal which areas each issue belongs to. If an issue spans multiple areas, it
+should have multiple area labels.
+
+Issue assignment is not required, but may be used to help track and highlight
+who is responding to particular issues. Each project area chooses whether they
+want to use issue assignment as part of their workflow or not.
+
+There are currently no required time frames or objectives for responding to
+issues across the project. There is however an expectation that issues are
+responded to by the maintainers of the relevant project area. In particular we
+have stale bot in place to prune inactive issues, and it doesn't look good if
+issues are marked as stale without a response.
+
+Our stale bot is in place both to close old issue, but also to keep bringing up
+existing issues to the forefront so that all issues throughout the project are
+considered at a regular cadence. If there is an issue that you want to leave
+open without having it marked as stale, you can add the `will-fix` label.
+
+### Pull Request Management
+
+The division of pull request among project areas is based on the GitHub reviewer
+feature, rather than labels or assignment. This is because it automatically
+works with the code owners feature, and also makes it possible for each team to
+decide if they want individual assignment of pull requests through the GitHub
+team settings.
+
+To aid in the pull request review process there is a
+[Pull Request Reviews](https://github.com/orgs/backstage/projects/2) GitHub
+project, where all incoming pull requests are automatically added. The "All" tab
+shows all pull requests, while "For Me" shows only the ones that you have been
+requested to review. The rest of the tabs show pull requests for each individual
+project area.
+
+Note that the project area tabs will not show pull requests that have been
+assigned to an individual maintainer, they will instead show up in their "For
+Me" tab.
+
+### Pull Request Reviews
+
+When reviewing pull requests you should always use the "request changes" option
+if you are leaving a review where you would not like the pull request to be
+merged as is. This is both to clarify to the author that the pull request is not
+ready to be merged, but also to update the status of the pull request in the
+pull request review board, more on that below. If you simply want to contribute
+to a discussion in the pull requests you can leave a regular comment.
+
+Even though a pull request may only change code owned by a single project area,
+it may indirectly affect other project areas or the project as a whole. If this
+is the case, reviews should be requested from the additional maintainer teams,
+and labels can be added for extra visibility. These are a few example where this
+would be applicable:
+
+1. A pull request adds a new way of using capabilities provided by a different
+   area, for example if the TechDocs plugin started utilizing the scaffolder
+   APIs in a novel way that is not already established or documented.
+1. A pull request introduces new platform level technologies such as new code
+   generation tools. In this case the core maintainers should be requested for
+   review.
+
+### Merging Pull Requests
+
+External contributions are merged by the owner of the modified code once the
+pull request has been approved and all critical status checks have passed. If
+there are multiple owners and it is not obvious that the pull request belongs to
+any particular area, then any owner may merge the pull requests as soon as it
+has been approved by all owners.
+
+Pull requests that are made by a project area maintainer within the same area
+are generally merged by the pull request author, although it is up to the
+maintainers of the area to decide if they want to use a different process.
+
+The core maintainers are able to and may occasionally merge pull requests
+without approval from all code owners. This is to be avoided, but might
+sometimes be necessary for emergency fixes. It is also done for the "Version
+Packages" pull requests that are part of our automated release process. This
+means that project area maintainers do not need to approve these pull requests
+every week.
+
+### Release Process
+
+Our release process is documented
+[here](https://github.com/backstage/backstage/blob/master/docs/publishing.md).
+The core maintainers are responsible for switching between next and main line
+releases as required.
+
+Releases happen every Tuesday, but there is no need to avoid merging pull
+requests during this time. If needed, the core maintainers will block the
+merging of pull requests in order to prepare for the release. As a project area
+maintainer, if there is a particular pull requests that you would like to have
+merged ahead of the release on a Tuesday, reach out to the core maintainers via
+Discord or similar medium.
+
+Pay attention to the release calendar and avoid merging significant changes
+ahead of main line releases. For impactful changes that aren't released as an
+experimental feature, it is often best to merge them just after a main line
+release. This ensures that the change gets as much time as possible in
+pre-releases before reaching stable.
+
+## Tools
+
+### Issue Triage
+
+### Triage Strategies
+
+#### Regularly Scheduled Sync
+
+meet every X, open issues, PR that need discussion
+
+filter by label
+
+#### Rotating "Goalie"
+
+### Pull Request Strategies
+
+#### Randomized Pull Request Assignment
+
+GitHub team settings ->
+
+#### Assignment during
+
+### Pull request pair/mob review
+
+Tricky PRs, one or more maintainers
+
+### Review Each Others' Pull Requests
+
+### Discord text channel
+
+### Discord voice channel

--- a/project-areas/README.md
+++ b/project-areas/README.md
@@ -1,0 +1,41 @@
+# Backstage Project Areas
+
+This directory contains external and internal information about many of the
+Backstage project areas. It is not required for a project area to be documented
+here. A full list of the Backstage project areas can be found in
+[OWNERS.md](https://github.com/backstage/backstage/blob/master/OWNERS.md#project-areas).
+
+## For Maintainers
+
+For project area maintainers that want to learn more about the common ways of
+working across project areas, as well different tools you can use within the
+project area, see [guidance.md](./Maintainer-Guidance.md).
+
+Each area owns their own documentation within this directory, please add
+yourselves as code owners.
+
+## FAQ
+
+### Why is X not a project area?
+
+There are many pieces of Backstage that could be their own project areas. In
+some cases there's a tradeoff to be made for how granular our division of the
+project is. It might be the case that a potential area is either too large or
+small in scope. Good guidelines for a project area is that it should not be
+trivially small, but also not larger than what a single team is able to manage.
+Project areas are also a permanent structure, in the sense that temporary
+working groups or task forces to not organize into a project area.
+
+The answer might also simply be that nobody has stepped up to drive the area, in
+which case, see the question below!
+
+### Can I start a new project area?
+
+Yes! If there is part of the project that you feel should be its own project
+area that you want to drive, reach out to the core maintainers. Be sure to
+familiarize yourself with the project
+[governance](https://github.com/backstage/backstage/blob/master/GOVERNANCE.md),
+especially the project area maintainer role and its responsibilities and
+requirements. In order to help onboard new areas, they can be created as
+incubating project areas, which means that the ownership will be shared with the
+Backstage core maintainers.

--- a/project-areas/README.md
+++ b/project-areas/README.md
@@ -9,7 +9,7 @@ here. A full list of the Backstage project areas can be found in
 
 For project area maintainers that want to learn more about the common ways of
 working across project areas, as well different tools you can use within the
-project area, see [guidance.md](./Maintainer-Guidance.md).
+project area, see [the guidance article](./Maintainer-Guidance.md).
 
 Each area owns their own documentation within this directory, please add
 yourselves as code owners.
@@ -24,7 +24,7 @@ project is. It might be the case that a potential area is either too large or
 small in scope. Good guidelines for a project area is that it should not be
 trivially small, but also not larger than what a single team is able to manage.
 Project areas are also a permanent structure, in the sense that temporary
-working groups or task forces to not organize into a project area.
+working groups or task forces do not organize themselves into a project area.
 
 The answer might also simply be that nobody has stepped up to drive the area, in
 which case, see the question below!

--- a/project-areas/README.md
+++ b/project-areas/README.md
@@ -39,3 +39,9 @@ especially the project area maintainer role and its responsibilities and
 requirements. In order to help onboard new areas, they can be created as
 incubating project areas, which means that the ownership will be shared with the
 Backstage core maintainers.
+
+### How come there are a lot more project area channels on Discord than there are project areas?
+
+The project area channels on Discord have been created to help focus discussions
+around specific parts of the project. Many of the channels could potentially
+become their own project areas with distinct ownership in the future.

--- a/project-areas/core/README.md
+++ b/project-areas/core/README.md
@@ -1,0 +1,23 @@
+# [Core Maintainers](https://github.com/backstage/backstage/blob/master/OWNERS.md#core-maintainers)
+
+Note that this document does not relate to a distinct project area, but instead
+the Backstage core maintainers team.
+
+## Ways of Working
+
+### Issue Triage
+
+The core maintainers use the
+[regularly scheduled sync](../Maintainer-Guidance.md#regularly-scheduled-sync)
+issue triage strategy. Every Monday and Thursday the core maintainers meet to
+walk through all issues with recent changes, as well as any pull request marked
+with the `needs-discussion` label.
+
+This meeting is not currently open to external participation.
+
+### Pull Request Reviews
+
+The core maintainers use the
+[randomized pull request assignment](../Maintainer-Guidance.md#randomized-pull-request-assignment)
+pull request review strategy. All incoming pull requests are distributed
+randomly and evenly among the maintainers.


### PR DESCRIPTION
This adds a new `project-areas` folder to this repo. At the root is a README with more information surrounding project areas, building upon the governance doc.

The main chunk of this PR is the new maintainer guidance doc, which describes common ways of working across project areas, as well a couple of different potential strategies for how to work within areas. You'll note that some of this is not reflected in reality, the plan is to fix that but also to agree on the way forward in this PR 😁 

I've also added an initial `project-areas/core` folder with a README that briefly describes some of the ways of working of the core maintainers. The idea is that each project area may have a folder at `project-areas/<name>` where any important information related to that area can be documented.

For visibility and extra 👀, let me know if you have any suggestions or questions:

@backstage/catalog-maintainers 
@backstage/discoverability-maintainers 
@backstage/helm-charts-maintainers 
@backstage/kubernetes-maintainers 
@backstage/techdocs-maintainers 
@backstage/openapi-tooling-maintainers 