### PR TITLE
Create sig-community-plugins

### DIFF
--- a/sigs/sig-community-plugins/README.md
+++ b/sigs/sig-community-plugins/README.md
@@ -4,9 +4,9 @@ The Community Plugins Special Interest Group (SIG) covers the setup and maintena
 
 ## Meetings
 
-SIG Community Plugins (biweekly), at TBD hours (tbd pm) Europe/Stockholm time [(convert to your time zone)](https://dateful.com/convert/stockholm-sweden?t=TBD).
+SIG Community Plugins (biweekly), at 16.00 hours (4 pm) Europe/Stockholm time [(convert to your time zone)](https://dateful.com/convert/stockholm-sweden?t=16).
 
-- [Video Meeting Link](#TODO)
+- [Video Meeting Link](https://meet.google.com/iub-fcyi-yag)
 - [Meeting Notes](https://docs.google.com/document/d/1lIHXi8fi3CDiUD8UhX7s1FWCKAiricQKnFR4OSHoaiY/edit) - Suggest topics for the next meeting here
 - See the [Backstage Community sessions](https://calendar.google.com/calendar/u/0?cid=Y19xdXA5Z2JobjlzcXB1YW82dHJ0dGQ4bWs1c0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) Google Calendar for upcoming meetings.
 
@@ -19,10 +19,6 @@ SIG Community Plugins (biweekly), at TBD hours (tbd pm) Europe/Stockholm time [(
 The SIG Community Plugins team is composed of:
 
 The organizers of the SIG, who run operations and processes governing the SIG.
-
-- TBD
-
-The Tech Leads of the SIG, who manage technical direction and have formal code ownership of subprojects that fall within the scope of this SIG. This includes for example establishing or decommissioning subprojects, resolving technical issues and decisions etc.
 
 - TBD
 

--- a/sigs/sig-community-plugins/README.md
+++ b/sigs/sig-community-plugins/README.md
@@ -21,8 +21,10 @@ The SIG Community Plugins team is composed of:
 The organizers of the SIG, who run operations and processes governing the SIG.
 
 - @BethGriggs
+- @kadel
 - @nickboldt
-- @kadel 
+- @tudi2d
+- @vinzscam
 
 ## Scope
 

--- a/sigs/sig-community-plugins/README.md
+++ b/sigs/sig-community-plugins/README.md
@@ -20,7 +20,9 @@ The SIG Community Plugins team is composed of:
 
 The organizers of the SIG, who run operations and processes governing the SIG.
 
-- TBD
+- @BethGriggs
+- @nickboldt
+- @kadel 
 
 ## Scope
 

--- a/sigs/sig-community-plugins/README.md
+++ b/sigs/sig-community-plugins/README.md
@@ -1,0 +1,33 @@
+# SIG Community Plugins
+
+The Community Plugins Special Interest Group (SIG) covers the setup and maintenance of the [Backstage community plugins repo](https://github.com/backstage/community-plugins).
+
+## Meetings
+
+SIG Community Plugins (biweekly), at TBD hours (tbd pm) Europe/Stockholm time [(convert to your time zone)](https://dateful.com/convert/stockholm-sweden?t=TBD).
+
+- [Video Meeting Link](#TODO)
+- [Meeting Notes](https://docs.google.com/document/d/1lIHXi8fi3CDiUD8UhX7s1FWCKAiricQKnFR4OSHoaiY/edit) - Suggest topics for the next meeting here
+- See the [Backstage Community sessions](https://calendar.google.com/calendar/u/0?cid=Y19xdXA5Z2JobjlzcXB1YW82dHJ0dGQ4bWs1c0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) Google Calendar for upcoming meetings.
+
+## Contact
+
+- Discord: [#community-plugins](https://discord.com/channels/687207715902193673/1201559534754345110)
+
+## Leadership
+
+The SIG Community Plugins team is composed of:
+
+The organizers of the SIG, who run operations and processes governing the SIG.
+
+- TBD
+
+The Tech Leads of the SIG, who manage technical direction and have formal code ownership of subprojects that fall within the scope of this SIG. This includes for example establishing or decommissioning subprojects, resolving technical issues and decisions etc.
+
+- TBD
+
+## Scope
+
+This SIG is an open space to meet and discuss the setup and ongoing maintenance of the Backstage community plugins repo.
+
+Discussions could for example cover what policies and checks to use in the repo, build tooling and structure, how to do issue triage and PR reviews. Discussions can also be more geared towards individual plugins, such as migrations in and out of the repo, or moving certain plugins in or out of active development.


### PR DESCRIPTION
This proposes the creation of a new community plugins SIG to discuss the setup and maintenance of the upcoming [community-plugins repo](https://github.com/backstage/community-plugins).

Draft for now as we iron out details.