### PR TITLE
Added "inactive" note to Backstage Users Unconference

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ For support or more immediate technical discussions, join us in [Discord](https:
 
 **Backstage Users Unconference, hosted by Roadie and Frontside**
 
+*Inactive since March 2022*
+
 [Backstage Users Unconference](https://hopin.com/events/backstage-users-unconference-mar-22) is a quarterly get-together of users sharing their experiences working with Backstage in their teams and insights about the ecosystem's plugins. Show up and suggest topics on the day.
 
 ## Newsletters


### PR DESCRIPTION
Link leads to event from March 2022 and it seems there were no further editions. Description in the README says it's quarterly event