### PR TITLE
GOVERNANCE.md: add path to become an org member as a plugin maintainer

### DIFF
--- a/.github/ISSUE_TEMPLATE/org_member.yaml
+++ b/.github/ISSUE_TEMPLATE/org_member.yaml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: >
-        Thank you for your interest and contributions to the Backstage project! 🙏
+        ### Thank you for your interest and contributions to the Backstage project! 🙏
 
   - type: markdown
     attributes:
@@ -17,34 +17,47 @@ body:
         In addition to becoming member of the Backstage GitHub organization, this role also
         comes with the responsibilities and requirements that are described in the governance.
 
-  - type: checkboxes
-    id: read-code-of-conduct
+  - type: markdown
     attributes:
-      label: 'Have you read the Code of Conduct?'
-      options:
-        - label: 'I have read the [Code of Conduct](https://github.com/backstage/backstage/blob/master/CODE_OF_CONDUCT.md)'
-          required: true
+      value: <br>
 
   - type: dropdown
-    id: contributor-time
+    id: member-type
     validations:
       required: true
     attributes:
-      label: 'Is your first contribution to Backstage at least 3 months ago?'
-      description: Organization members need to have been contributing for at least 3 months, or be a member of a Project Area Maintainer team.
+      label: 'Through which path are you seeking to become an organization member?'
       options:
-        - 'No'
-        - Yes, I have been contributing to Backstage for at least 3 months
-        - No, but I am the member of a Project Area Maintainer team in my organization
+        - 1. I have been contributing for at least 3 months and wish to become a standalone org-member
+        - 2. The team that I am a member of in my organization are maintainers of a Project Area in Backstage
+        - 3. I am a maintainer of a plugin the Backstage Community Plugins Repository
+
+  - type: markdown
+    attributes:
+      value: <br>
 
   - type: textarea
     id: contributions
-    validations:
-      required: true
     attributes:
-      label: 'Highlighted Contributions'
-      description: 'The Backstage governance requires that organization members have made some contributions to the project. Please choose a couple (3-5) of these contributions that you would like to highlight. If you are the member of a Project Area Maintainer team, please let us know your organization, team, and project area instead.'
+      label: 'If option 1: Highlighted Contributions'
+      description: 'The Backstage governance requires that standalone organization members have made some contributions to the project. Please choose a couple (3-5) of these contributions that you would like to highlight. If you are the member of a Project Area Maintainer team, please let us know your organization, team, and project area instead.'
       placeholder: 'Link to GitHub issues, accepted PRs, or other contributions that you would like to highlight'
+
+  - type: input
+    id: project-area
+    attributes:
+      label: 'If option 2: Project Area'
+      description: 'Please specify the project area that your team maintains'
+
+  - type: input
+    id: plugin-owner
+    attributes:
+      label: 'If option 3: Plugin code owner PR'
+      description: 'Please link to the pull request where you were added as a code owner of a plugin in the community-plugins repository'
+
+  - type: markdown
+    attributes:
+      value: <br>
 
   - type: input
     id: discord-username
@@ -64,3 +77,11 @@ body:
     id: other
     attributes:
       label: 'Any other context that you wish to share'
+
+  - type: checkboxes
+    id: read-code-of-conduct
+    attributes:
+      label: 'Have you read the Code of Conduct?'
+      options:
+        - label: 'I have read the [Code of Conduct](https://github.com/backstage/backstage/blob/master/CODE_OF_CONDUCT.md)'
+          required: true

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,8 +20,8 @@ in the [Backstage GitHub organization](https://github.com/backstage).
 
 ## Code of Conduct
 
-All members of the Backstage community are expected to follow the [CNCF Code of
-Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+All members of the Backstage community are expected to follow the
+[CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
 
 ## Project Areas
 
@@ -119,15 +119,25 @@ of a Contributor.
 
 #### Requirements
 
-- Must have at least 10 contributions to the projects in the form of:
-  - Accepted PRs
-  - Helpful PR reviews
-  - Resolving GitHub issues
-  - Or some equivalent contributions to the project
-- Must have been contributing for at least 3 months
-- Or is the member of a team that owns a project area, in which case the above
-  requirements do not apply and the member is instead vetted by the project area
-  maintainers
+There are three different paths to becoming an Organization Member:
+
+1. Individual org-member path:
+   - Must have at least 10 contributions to the projects in the form of:
+     - Accepted PRs
+     - Helpful PR reviews
+     - Resolving GitHub issues
+     - Or some equivalent contributions to the project
+   - Must have been contributing for at least 3 months
+2. Team member of an existing project area maintainer team:
+   - In the case where a team at an organization owns a project area, all the
+     members of that team are automatically able to become both Organization
+     Members and Project Area Maintainers. This must be approved by at least one
+     of the existing project area maintainers.
+3. Plugin maintainer:
+   - In the event that a contributor is granted Plugin Maintainer status, they
+     are automatically also granted Organization Member status. This must be
+     approved by at least one of the existing Community Plugin Project Area
+     Maintainers.
 
 #### Becoming an Organization Member
 
@@ -142,7 +152,9 @@ Open an issue towards
 ### Plugin Maintainer
 
 A Plugin Maintainer is responsible for maintaining an individual Backstage
-plugin or module. This includes reviewing contributions and responding to issues
+plugin or module in the
+[backstage/community-plugins](https://github.com/backstage/community-plugins)
+repository. This includes reviewing contributions and responding to issues
 towards an individual plugin, as well as keeping the plugin up to date.
 
 Plugin Maintainer is a lightweight form of ownership that is reflected though
@@ -164,15 +176,21 @@ Member.
 
 #### Requirements
 
-- Is an Organization Member
 - Display knowledge of Backstage's review process and best practices for plugin
   design
 - Is supportive of new and occasional contributors and helps get useful PRs in
   shape to merge
+- Owns at least one plugin in the
+  [backstage/community-plugins](https://github.com/backstage/community-plugins)
+  repository. For details on how to contribute a plugin, see the
+  [Backstage Community Plugins README.md](https://github.com/backstage/community-plugins/blob/main/README.md)
 
 #### Privileges
 
-- GitHub code owner of the plugin directory, with rights to approve and merge
+- Write access to the
+  [backstage/community-plugins](https://github.com/backstage/community-plugins)
+  repository
+- GitHub code owner of the plugin workspace, with rights to approve and merge
   PRs towards the plugin
 
 #### Becoming a Plugin Maintainer


### PR DESCRIPTION
I propose the the following update to our governance in order to simplify the process for becoming an org member with write access (i.e. code ownership) in the community plugins repository.

We discussed the need for this update in today's community plugins SIG, but we've also been discussing something similar in the core maintainers team for a while too. Right now it's too hard to become an org member, to the point where it adds significant friction to both the contribution and maintenance of the community plugins. It's not spelled out plainly in the updated text, but this effectively makes the community plugins project area maintainers the gatekeepers for who can become an org member by being a plugin maintainer, since they approve those contributions.

The idea is that write access is still based on maintainer and contributor status, i.e. project area maintainers get write access to relevant repos, and plugin maintainers get write access to the community plugins repo.