### PR TITLE
sigs/sig-adoption: pause recurring meetings

### DIFF
--- a/sigs/sig-adoption/README.md
+++ b/sigs/sig-adoption/README.md
@@ -4,11 +4,14 @@ The Adoption Special Interest Group (SIG) covers all aspects of the adoption jou
 
 ## Meetings
 
-SIG Adoption (biweekly), at 16.00 hours (4 pm) Europe/Stockholm time [(convert to your time zone)](https://dateful.com/convert/stockholm-sweden?t=16).
+> [!IMPORTANT]
+> The recurring meetings are currently paused - Please reach out via the Discord channel to organize an ad-hoc meeting instead
+
+~SIG Adoption (biweekly), at 16.00 hours (4 pm) Europe/Stockholm time [(convert to your time zone)](https://dateful.com/convert/stockholm-sweden?t=16).~
 
 - [Video Meeting Link](https://meet.google.com/bbj-ojbi-knt)
 - [Meeting Notes](https://docs.google.com/document/d/1zeYSzXYgh897bxPQmwy2btOwCFlEjlUDLf00riySLRc/edit?usp=sharing) - Suggest topics for the next meeting here
-- See the [Backstage Community sessions](https://calendar.google.com/calendar/u/0?cid=Y19xdXA5Z2JobjlzcXB1YW82dHJ0dGQ4bWs1c0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) Google Calendar for upcoming meetings.
+- ~See the [Backstage Community sessions](https://calendar.google.com/calendar/u/0?cid=Y19xdXA5Z2JobjlzcXB1YW82dHJ0dGQ4bWs1c0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) Google Calendar for upcoming meetings.~
 
 ## Contact
 


### PR DESCRIPTION
Suggesting this due to low attendance and sparse discussion topics. I think there's a bit too much overlap with the new framework and adoption SIGs at this point. Figured we can keep the SIG organization, channel, and docs around for the time being, and organize meetings ad-hoc instead.