### PR TITLE
doc: Adding sig-docs to the list of SIGs

### DIFF
--- a/sigs/README.md
+++ b/sigs/README.md
@@ -6,6 +6,7 @@ Active SIGs
 
 - [sig-adoption](./sig-adoption/README.md)
 - [sig-community-plugins](./sig-community-plugins/README.md)
+- [sig-docs](./sig-docs/README.md)
 - [sig-framework](./sig-framework/README.md)
 - [sig-scaffolder](./sig-scaffolder/README.md)
 


### PR DESCRIPTION
Adding sig-docs to the list of SIGs in the main SIGs README.