### PR TITLE
add org membership responsibilities checkbox to org_member issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/org_member.yaml
+++ b/.github/ISSUE_TEMPLATE/org_member.yaml
@@ -78,15 +78,15 @@ body:
     attributes:
       label: 'Any other context that you wish to share'
 
-- type: checkboxes
-  id: read-org-member-responsibilities
-  attributes:
-    label: 'Have you read the Organization Member responsibilities?'
-    options:
-      - label: >
-          I have read and understood the [Organization Member responsibilities](https://github.com/backstage/community/blob/master/GOVERNANCE.md#organization-member).
-          If applying via option 3 (Plugin Maintainer), I have also reviewed the [Plugin Maintainer section](https://github.com/backstage/community/blob/master/GOVERNANCE.md#plugin-maintainer).
-        required: true
+  - type: checkboxes
+    id: read-org-member-responsibilities
+    attributes:
+      label: 'Have you read the Organization Member responsibilities?'
+      options:
+        - label: >
+            I have read and understood the [Organization Member responsibilities](https://github.com/backstage/community/blob/master/GOVERNANCE.md#organization-member).
+            If applying via option 3 (Plugin Maintainer), I have also reviewed the [Plugin Maintainer section](https://github.com/backstage/community/blob/master/GOVERNANCE.md#plugin-maintainer).
+          required: true
 
   - type: checkboxes
     id: read-code-of-conduct

--- a/.github/ISSUE_TEMPLATE/org_member.yaml
+++ b/.github/ISSUE_TEMPLATE/org_member.yaml
@@ -78,6 +78,16 @@ body:
     attributes:
       label: 'Any other context that you wish to share'
 
+- type: checkboxes
+  id: read-org-member-responsibilities
+  attributes:
+    label: 'Have you read the Organization Member responsibilities?'
+    options:
+      - label: >
+          I have read and understood the [Organization Member responsibilities](https://github.com/backstage/community/blob/master/GOVERNANCE.md#organization-member).
+          If applying via option 3 (Plugin Maintainer), I have also reviewed the [Plugin Maintainer section](https://github.com/backstage/community/blob/master/GOVERNANCE.md#plugin-maintainer).
+        required: true
+
   - type: checkboxes
     id: read-code-of-conduct
     attributes:


### PR DESCRIPTION
As discussed during the community plugins SIG, this PR adds a required checkbox to the organization membership request template to ensure that applicants have read the [Organization Member responsibilities](https://github.com/backstage/community/blob/master/GOVERNANCE.md#organization-member).

It also includes a note asking applicants to specifically review the [Plugin Maintainer section](https://github.com/backstage/community/blob/master/GOVERNANCE.md#plugin-maintainer) if they are applying through the third option.