### PR TITLE
catalog-info.yaml: fix spec

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,6 +5,6 @@ metadata:
   annotations:
     github.com/project-slug: 'backstage/community'
 spec:
-  type: service
+  type: documentation
   lifecycle: production
-  owner: spotify
+  owner: CNCF


### PR DESCRIPTION
This was merged by mistake in https://github.com/backstage/community/pull/212.

Branch protection rules are now in place, but having a `catalog-info.yaml` kinda makes sense, just aligning it with https://github.com/backstage/backstage/blob/master/catalog-info.yaml