### PR TITLE
GOVERNANCE.md: Set core maintainer commitment to 7 days per month

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -344,7 +344,7 @@ Maintainer.
 - Is able to exercise judgment for the good of the project, independent of their
   employer, friends, or team
 - Mentors other contributors
-- Can commit to spending at least 10 days per month working on the project
+- Can commit to spending at least 7 days per month working on the project
 
 #### Privileges
 


### PR DESCRIPTION
With the new reinforcements in https://github.com/backstage/backstage/pull/32114 I'm proposing we lower the core maintainer commitment from 10 to 7 days per month, to reduce pressure on both old and new maintainers. 35 is still more than 30 😁

@backstage/maintainers 👀 